### PR TITLE
Alterando json de retorno dos documentos

### DIFF
--- a/archives_app/documents_serializers.py
+++ b/archives_app/documents_serializers.py
@@ -4,36 +4,105 @@ from archives_app.documents_models import (FrequencyRelation, ArchivalRelation,
                                            FrequencySheet)
 
 
-class ArchivalRelationSerializer(serializers.ModelSerializer):
-    # abbreviation_id = serializers.ForeignKey(BoxAbbreviations, on_delete=models.PROTECT,
-    #                                     required=False)
-    # shelf_id = serializers.ForeignKey(Shelf, on_delete=models.PROTECT, required=False)
-    # notes = serializers.CharField(max_length=300, required=False)
-    # number_of_boxes = serializers.IntegerField(required=False)
-    # document_url = serializers.URLField(required=False)
-    # cover_sheet = serializers.CharField(max_length=100, required=False)
+class ObjectNames(serializers.ModelSerializer):
+    def get_shelf_number(self, obj):
+        if obj.shelf_id is not None:
+            return obj.shelf_id.number
+        return 0
+
+    def get_rack_number(self, obj):
+        if obj.rack_id is not None:
+            return obj.rack_id.number
+        return 0
+
+    def get_abbreviation_name(self, obj):
+        if obj.abbreviation_id is not None:
+            return obj.abbreviation_id.name
+        return ""
+
+    shelf_number = serializers.SerializerMethodField('get_shelf_number')
+    rack_number = serializers.SerializerMethodField('get_rack_number')
+    abbreviation_name = serializers.SerializerMethodField('get_abbreviation_name')
+
+
+class ArchivalRelationSerializer(ObjectNames):
 
     class Meta:
         model = ArchivalRelation
-        fields = '__all__'
+        fields = (
+            "id",
+            "process_number",
+            "sender_unity",
+            "notes",
+            "number",
+            "received_date",
+            "number_of_boxes",
+            "document_url",
+            "cover_sheet",
+            "filer_user",
+            "document_type_id",
+            "abbreviation_name",
+            "shelf_number",
+            "rack_number",
+            "origin_box_id",
+            "abbreviation_id",
+            "shelf_id",
+            "rack_id"
+        )
 
 
-class FrequencyRelationSerializer(serializers.ModelSerializer):
-    # abbreviation_id = serializers.ForeignKey(BoxAbbreviations, on_delete=models.PROTECT,
-    #                                     required=False)
-    # shelf_id = serializers.ForeignKey(Shelf, on_delete=models.PROTECT, required=False)
-    # notes = serializers.CharField(max_length=300, required=False)
+class FrequencyRelationSerializer(ObjectNames):
 
     class Meta:
         model = FrequencyRelation
-        fields = '__all__'
+        fields = (
+            "id",
+            "process_number",
+            "notes",
+            "filer_user",
+            "number",
+            "received_date",
+            "reference_period",
+            "sender_unity",
+            "abbreviation_name",
+            "shelf_number",
+            "rack_number",
+            "document_type_id",
+            "abbreviation_id",
+            "shelf_id",
+            "rack_id"
+        )
 
 
-class AdministrativeProcessSerializer(serializers.ModelSerializer):
+class AdministrativeProcessSerializer(ObjectNames):
 
     class Meta:
         model = AdministrativeProcess
-        fields = '__all__'
+        fields = ("id",
+                  "process_number",
+                  "notes",
+                  "filer_user",
+                  "notice_date",
+                  "interested",
+                  "cpf_cnpj",
+                  "reference_month_year",
+                  "sender_user",
+                  "archiving_date",
+                  "is_filed",
+                  "is_eliminated",
+                  "send_date",
+                  "administrative_process_number",
+                  "sender_unity",
+                  "abbreviation_name",
+                  "subject_id",
+                  "dest_unity_id",
+                  "unity_id",
+                  "shelf_number",
+                  "rack_number",
+                  "abbreviation_id",
+                  "shelf_id",
+                  "rack_id"
+                  )
 
 
 class OriginBoxSerializer(serializers.ModelSerializer):
@@ -43,13 +112,23 @@ class OriginBoxSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
-class FrequencySheetSerializer(serializers.ModelSerializer):
-    # abbreviation_id = serializers.ForeignKey(BoxAbbreviations, on_delete=models.PROTECT,
-    #                                         required=False)
-    # shelf_id = serializers.ForeignKey(Shelf, on_delete=models.PROTECT, required=False)
-    # notes = serializers.CharField(max_length=300, required=False)
-    # process_number = serializers.CharField(max_length=20, required=False)
+class FrequencySheetSerializer(ObjectNames):
 
     class Meta:
         model = FrequencySheet
-        fields = '__all__'
+        fields = ("id",
+                  "person_name",
+                  "cpf",
+                  "role",
+                  "category",
+                  "workplace",
+                  "municipal_area",
+                  "reference_period",
+                  "notes",
+                  "process_number",
+                  "abbreviation_id",
+                  "shelf_id",
+                  "rack_id",
+                  "abbreviation_name",
+                  "shelf_number",
+                  "rack_number")

--- a/archives_app/views.py
+++ b/archives_app/views.py
@@ -145,6 +145,11 @@ class ArchivalRelationView(views.APIView):
             archival_relation.shelf_id = shelf_number_id
             archival_relation.save()
 
+        if request.data['rack_id'] != '':
+            rack_number_id = Rack.objects.get(pk=request.data['rack_id'])
+            archival_relation.rack_id = rack_number_id
+            archival_relation.save()
+
         for box in boxes:
             archival_relation.origin_box_id.add(box.id)
 

--- a/tests/urls_tests.py
+++ b/tests/urls_tests.py
@@ -1,5 +1,8 @@
 import pytest
 from rest_framework.test import APIClient
+from archives_app.documents_serializers import FrequencySheetSerializer
+from archives_app.documents_models import FrequencySheet
+from archives_app.fields_models import Shelf, Rack, BoxAbbreviations
 
 
 @pytest.mark.django_db(transaction=False)
@@ -645,3 +648,31 @@ def test_search():
 
     response = api_client.get('/search/?filter=%7B%22notes%22:%221%22%7D')
     assert response.status_code == 200
+
+
+@pytest.mark.django_db(transaction=False)
+def test_get_shelf_number():
+
+    s = Shelf.objects.create(number=123)
+    r = Rack.objects.create(number=123)
+    b = BoxAbbreviations.objects.create(name="a")
+
+    f = FrequencySheet.objects.create(
+        person_name="teste",
+        cpf="1",
+        role="teste",
+        category="teste",
+        workplace="teste",
+        municipal_area="teste",
+        reference_period=["2020-11-11"],
+        abbreviation_id=b,
+        shelf_id=s,
+        rack_id=r,
+        notes=None,
+        process_number="1"
+    )
+
+    f_s = FrequencySheetSerializer(f)
+    assert f_s.get_shelf_number(f) == 123
+    assert f_s.get_rack_number(f) == 123
+    assert f_s.get_abbreviation_name(f) == 'a'

--- a/tests/urls_tests.py
+++ b/tests/urls_tests.py
@@ -1,6 +1,5 @@
 import pytest
 from rest_framework.test import APIClient
-from .serializers import ObjectSerializer
 
 
 @pytest.mark.django_db(transaction=False)

--- a/tests/urls_tests.py
+++ b/tests/urls_tests.py
@@ -453,7 +453,8 @@ class TestFrequencySheetsEndpoints:
         "process_number": "1",
         "reference_period": ["2020-11-11"],
         "abbreviation_id": "",
-        "shelf_id": ""
+        "shelf_id": "",
+        "rack_id": ""
     }
 
     def test_create(self):
@@ -582,6 +583,7 @@ def archival_relation_data():
         "filer_user": "1",
         "abbreviation_id": "",
         "shelf_id": "",
+        "rack_id": "",
         "document_type_id": response_type.data['id']
     }
 
@@ -602,6 +604,8 @@ def test_archival_relation_get_pk():
     response_archival_get = api_client.get(
         '/archival-relation/')
     assert response_archival_get.status_code == 200
+
+    print(response_archival_get.data[0])
 
     response = api_client.get('/archival-relation/{}'.format(
         response_archival_get.data[0]['id']))

--- a/tests/urls_tests.py
+++ b/tests/urls_tests.py
@@ -1,5 +1,6 @@
 import pytest
 from rest_framework.test import APIClient
+from .serializers import ObjectSerializer
 
 
 @pytest.mark.django_db(transaction=False)
@@ -610,6 +611,14 @@ def test_archival_relation_get_pk():
     response = api_client.get('/archival-relation/{}'.format(
         response_archival_get.data[0]['id']))
     assert response.status_code == 200
+
+
+@pytest.mark.django_db(transaction=False)
+def test_archival_relation_get_pk_except():
+    api_client = APIClient()
+
+    response = api_client.get('/archival-relation/4000')
+    assert response.status_code == 404
 
 
 @pytest.mark.django_db(transaction=False)


### PR DESCRIPTION
## Descrição 
Foi alterado o retorno dos valores que são foreign keys, para não retornar apenas o ID, mas os valores do objeto completo.

## Issue Correspondente
[#117](https://github.com/fga-eps-mds/2021.1-PC-GO1/issues/117)

## Checklist 

* [ ] Nome do pull request significativo e representa o que está sendo submetido.
* [ ] Passou nos testes de integração
* [ ] Branch de acordo com a política de gerenciamento e configuração
* [ ] Critérios de aceitação cumpridos
* [ ] Caso necessário, realizou teste correspondente às funcionalidades implementadas.
* [ ] Revisor marcado

## Anexos
![Screenshot_20210930_145856](https://user-images.githubusercontent.com/37306250/135507362-7e0ecfcb-37ee-4164-9036-d08e4dbe811f.png)

